### PR TITLE
added frame arg to dingo launch

### DIFF
--- a/robot/dingo/launch/control.launch
+++ b/robot/dingo/launch/control.launch
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
   <arg name="robot_namespace" />
+  <arg name="frame" />
 
   <rosparam command="load" file="$(find arena-simulation-setup)/robot/dingo/control.yaml" />
 


### PR DESCRIPTION
Added   <arg name="frame" /> to dingo launch file to avoid 

roslaunch.core.RLException: unused args [frame] for include of [/home/jonas/arena_ws/src/arena-simulation-setup/robot/dingo/launch/control.launch]

which killed the process

@voshch 